### PR TITLE
fix(deploy): specify Dockerfile path in build command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,10 +37,10 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker build -f docker/Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
-
       # --- Deployment to DEV Environment ---
       - name: Prepare new task definition for DEV
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
fix(deploy): specify Dockerfile path in build command

- Updated the Docker build command in the GitHub Actions workflow to explicitly reference the Dockerfile location, improving clarity and ensuring the correct file is used during the build process.