### PR TITLE
fix(package): move swagger-jsdoc to dev dependencies in package.json

### DIFF
--- a/TODO-Nilesh
+++ b/TODO-Nilesh
@@ -1,0 +1,1 @@
+- REMOVE swagger-jsdoc from dependency and move it to dev dependency

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "prettier": "^3.6.2",
     "prisma": "^6.14.0",
     "supertest": "^7.0.0",
-    "swagger-jsdoc": "^6.2.8",
     "ts-jest": "^29.4.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2",
@@ -86,6 +85,7 @@
     "morgan": "^1.10.1",
     "multer": "^2.0.0",
     "nodemailer": "^7.0.5",
+    "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1"
   },
   "lint-staged": {


### PR DESCRIPTION
- Removed swagger-jsdoc from regular dependencies and added it to dev dependencies, aligning with best practices for development tools.
