### PR TITLE
fix(docker): update npm install command in Dockerfile for production build

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -20,7 +20,7 @@ ENV NODE_ENV=production
 
 # Copy only production packages and package.json
 COPY package*.json ./
-RUN npm ci --only=production --ignore-scripts
+RUN npm ci
 
 # Copy the built application and necessary Prisma assets from the builder stage
 COPY --from=builder /usr/src/app/dist ./dist


### PR DESCRIPTION
- Changed the npm install command in the Dockerfile to run without the --only=production and --ignore-scripts flags, ensuring all necessary packages are installed for the production environment.