### PR TITLE
refactor(task-definitions): remove health check configuration from AWS task definitions

### DIFF
--- a/aws/task-defination-dev.json
+++ b/aws/task-defination-dev.json
@@ -27,16 +27,6 @@
                   "appProtocol": "http"
               }
           ],
-          "healthCheck": {
-              "command": [
-                  "CMD-SHELL",
-                  "curl -f http://localhost:3000/health || exit 1"
-              ],
-              "interval": 30,
-              "timeout": 5,
-              "retries": 3,
-              "startPeriod": 60
-          },
           "logConfiguration": {
               "logDriver": "awslogs",
               "options": {

--- a/aws/task-defination-prod.json
+++ b/aws/task-defination-prod.json
@@ -27,16 +27,6 @@
                   "appProtocol": "http"
               }
           ],
-          "healthCheck": {
-              "command": [
-                  "CMD-SHELL",
-                  "curl -f http://localhost:3000/health || exit 1"
-              ],
-              "interval": 30,
-              "timeout": 5,
-              "retries": 3,
-              "startPeriod": 60
-          },
           "logConfiguration": {
               "logDriver": "awslogs",
               "options": {


### PR DESCRIPTION
- Eliminated health check settings from both development and production AWS task definition files to streamline configuration.
